### PR TITLE
Copy as YAML instead of JSON

### DIFF
--- a/demo/webpack.config.ts
+++ b/demo/webpack.config.ts
@@ -158,7 +158,6 @@ export default (env: { playground?: boolean; bench?: boolean } = {}, { mode }) =
         : 'demo/index.html',
     }),
     new ForkTsCheckerWebpackPlugin(),
-    ignore(/js-yaml\/dumper\.js$/),
     ignore(/json-schema-ref-parser\/lib\/dereference\.js/),
     ignore(/^\.\/SearchWorker\.worker$/),
     new CopyWebpackPlugin(['demo/openapi.yaml']),

--- a/src/components/JsonViewer/JsonViewer.tsx
+++ b/src/components/JsonViewer/JsonViewer.tsx
@@ -7,6 +7,7 @@ import { PrismDiv } from '../../common-elements/PrismDiv';
 import { jsonToHTML } from '../../utils/jsonToHtml';
 import { OptionsContext } from '../OptionsProvider';
 import { jsonStyles } from './style';
+import * as yaml from 'js-yaml';
 
 export interface JsonProps {
   data: any;
@@ -23,8 +24,12 @@ class Json extends React.PureComponent<JsonProps> {
   node: HTMLDivElement;
 
   render() {
-    return <CopyButtonWrapper data={this.props.data}>{this.renderInner}</CopyButtonWrapper>;
+    return <CopyButtonWrapper data={this.yamlData()}>{this.renderInner}</CopyButtonWrapper>;
   }
+
+  yamlData = () => {
+    return yaml.dump(JSON.parse(JSON.stringify(this.props.data)));
+  };
 
   renderInner = ({ renderCopyButton }) => (
     <JsonViewerWrap>

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -147,7 +147,6 @@ export default (env: { standalone?: boolean } = {}, { mode }) => ({
     }),
     new ForkTsCheckerWebpackPlugin({ silent: true }),
     new webpack.BannerPlugin(BANNER),
-    ignore(/js-yaml\/dumper\.js$/),
     ignore(/json-schema-ref-parser\/lib\/dereference\.js/),
     env.standalone ? ignore(/^\.\/SearchWorker\.worker$/) : ignore(/$non-existing^/),
   ],


### PR DESCRIPTION
This is just a quick hack to get the "copy" functionality to YAML to the clipboard instead of JSON.